### PR TITLE
fix: dice tray canvas was blocking all touches when overlay closed

### DIFF
--- a/components/dice-overlay.tsx
+++ b/components/dice-overlay.tsx
@@ -320,7 +320,7 @@ export default function DiceOverlay() {
           id="dice-tray-overlay"
           ref={containerRef}
           className="absolute inset-0 w-screen h-screen z-45"
-          style={{ pointerEvents: hasRolled ? 'none' : 'auto' }}
+          style={{ pointerEvents: isDiceOverlayOpen && !hasRolled ? 'auto' : 'none' }}
         />
       </div>
 


### PR DESCRIPTION
The dice-tray-overlay had pointer-events: auto when hasRolled was false, but hasRolled defaults to false. This meant the invisible canvas was capturing all touch events even when the overlay wasn't open.

Child pointer-events: auto overrides parent pointer-events: none in CSS.

Fix: Only enable pointer-events when overlay is open AND hasn't rolled yet.