### PR TITLE
feat(#71): Add dynamic class/domain helpers for playtest support

### DIFF
--- a/__tests__/lib/multiclass.test.ts
+++ b/__tests__/lib/multiclass.test.ts
@@ -1,13 +1,119 @@
 /**
  * Tests for Multiclass Helper Functions
  *
- * Tests the getClassDomains and getAllClassNames functions.
+ * Tests both deprecated (hard-coded) and new dynamic functions.
  */
 
 import { describe, it, expect } from 'vitest';
-import { getClassDomains, getAllClassNames } from '@/lib/level-up-helpers';
+import {
+  getClassDomains,
+  getAllClassNames,
+  getClassDomainsFromData,
+  getClassNamesFromData,
+  getSubclassesFromData
+} from '@/lib/level-up-helpers';
 
-describe('getClassDomains', () => {
+// ============================================================================
+// Tests for NEW DYNAMIC functions (preferred - work with any class)
+// ============================================================================
+
+describe('getClassDomainsFromData (dynamic)', () => {
+  it('should return domains from class data', () => {
+    const classData = { data: { domains: ['Blade', 'Valor'] } };
+    expect(getClassDomainsFromData(classData)).toEqual(['Blade', 'Valor']);
+  });
+
+  it('should return empty array when data is null', () => {
+    expect(getClassDomainsFromData(null)).toEqual([]);
+  });
+
+  it('should return empty array when data is undefined', () => {
+    expect(getClassDomainsFromData(undefined)).toEqual([]);
+  });
+
+  it('should return empty array when domains are missing', () => {
+    const classData = { data: {} };
+    expect(getClassDomainsFromData(classData)).toEqual([]);
+  });
+
+  it('should work with playtest class data', () => {
+    const playtestClass = { data: { domains: ['Void', 'Midnight'] } };
+    expect(getClassDomainsFromData(playtestClass)).toEqual(['Void', 'Midnight']);
+  });
+});
+
+describe('getClassNamesFromData (dynamic)', () => {
+  it('should return names from class array', () => {
+    const classes = [
+      { name: 'Warrior' },
+      { name: 'Bard' },
+      { name: 'VoidWalker' } // Playtest class
+    ];
+    expect(getClassNamesFromData(classes)).toEqual(['Warrior', 'Bard', 'VoidWalker']);
+  });
+
+  it('should return empty array for empty input', () => {
+    expect(getClassNamesFromData([])).toEqual([]);
+  });
+});
+
+describe('getSubclassesFromData (dynamic)', () => {
+  const allSubclasses = [
+    { id: 'subclass-stalwart', name: 'Stalwart', data: { parent_class_id: 'class-guardian' } },
+    { id: 'subclass-vengeance', name: 'Vengeance', data: { parent_class_id: 'class-guardian' } },
+    { id: 'subclass-troubadour', name: 'Troubadour', data: { parent_class_id: 'class-bard' } },
+    { id: 'subclass-voidbender', name: 'Voidbender', data: { parent_class_id: 'class-voidwalker' } },
+  ];
+
+  it('should return subclasses matching parent_class_id', () => {
+    const guardianClass = { id: 'class-guardian', name: 'Guardian', data: {} };
+    const result = getSubclassesFromData(guardianClass, allSubclasses);
+    expect(result).toHaveLength(2);
+    expect(result.map(s => s.name)).toEqual(['Stalwart', 'Vengeance']);
+  });
+
+  it('should return subclasses matching subclass_names', () => {
+    const bardClass = { id: 'class-bard', name: 'Bard', data: { subclass_names: ['Troubadour', 'Wordsmith'] } };
+    const result = getSubclassesFromData(bardClass, allSubclasses);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Troubadour');
+  });
+
+  it('should return empty array when classData is null', () => {
+    expect(getSubclassesFromData(null, allSubclasses)).toEqual([]);
+  });
+
+  it('should work with playtest classes', () => {
+    const playtestClass = { id: 'class-voidwalker', name: 'VoidWalker', data: {} };
+    const result = getSubclassesFromData(playtestClass, allSubclasses);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Voidbender');
+  });
+
+  it('should preserve full subclass type in return value', () => {
+    const extendedSubclasses = [
+      {
+        id: 'subclass-stalwart',
+        name: 'Stalwart',
+        data: {
+          parent_class_id: 'class-guardian',
+          description: 'A defensive warrior',
+          foundation_features: [{ name: 'Shield Wall' }]
+        }
+      },
+    ];
+    const guardianClass = { id: 'class-guardian', name: 'Guardian', data: {} };
+    const result = getSubclassesFromData(guardianClass, extendedSubclasses);
+    expect(result[0].data?.description).toBe('A defensive warrior');
+    expect(result[0].data?.foundation_features).toBeDefined();
+  });
+});
+
+// ============================================================================
+// Tests for DEPRECATED functions (SRD-only, kept for backward compatibility)
+// ============================================================================
+
+describe('getClassDomains (deprecated - SRD only)', () => {
   describe('returns correct domains for each class', () => {
     it('should return Codex and Grace for Bard', () => {
       const domains = getClassDomains('Bard');
@@ -92,7 +198,7 @@ describe('getClassDomains', () => {
   });
 });
 
-describe('getAllClassNames', () => {
+describe('getAllClassNames (deprecated - SRD only)', () => {
   it('should return all 9 class names', () => {
     const classNames = getAllClassNames();
     expect(classNames).toHaveLength(9);

--- a/components/views/character/level-up/level-up-modal.tsx
+++ b/components/views/character/level-up/level-up-modal.tsx
@@ -49,7 +49,7 @@ import React, { useState } from 'react';
 import { X, Zap, Check, Search, PawPrint, ChevronUp, ChevronDown } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { RangerCompanion } from '@/types/character';
-import { calculateTierAchievements, calculateNewDamageThresholds, getTier, getMaxCardLevelForDomain, getClassDomains } from '@/lib/level-up-helpers';
+import { calculateTierAchievements, calculateNewDamageThresholds, getTier, getMaxCardLevelForDomain, getClassDomainsFromData } from '@/lib/level-up-helpers';
 import { validateNewLevel, validateAdvancementSelections } from '@/lib/level-up-validation';
 import { getCardLevel, getCardDescription, getCardType, isCardInDomain, isCardAvailableAtLevel } from '@/lib/card-helpers';
 import MulticlassSelection from './multiclass-selection';
@@ -205,7 +205,8 @@ export default function LevelUpModal({
     // 3. Max Level Rule - Use helper function to apply half-level rule for multiclass domains
     // Get primary domains from the character's actual domains (not hardcoded class domains)
     // This handles characters with non-standard domain choices correctly
-    const primaryDomains = character.domains || (character.class_id ? getClassDomains(character.class_id) : []);
+    const classData = character.class_id ? classes.find((c: any) => c.name === character.class_id) : null;
+    const primaryDomains = character.domains || getClassDomainsFromData(classData);
 
     // Determine multiclass domain to apply half-level rule (SRD: multiclass cards limited to half character level)
     // This handles two scenarios:
@@ -218,7 +219,8 @@ export default function LevelUpModal({
     } else if (character.multiclass_id) {
       // Scenario B: Character already has a multiclass - find the domain from the multiclass class
       // Use the multiclass class's domains to identify which domain came from multiclassing
-      const multiclassClassDomains = getClassDomains(character.multiclass_id);
+      const multiclassClassData = classes.find((c: any) => c.name === character.multiclass_id);
+      const multiclassClassDomains = getClassDomainsFromData(multiclassClassData);
       const existingMulticlassDomain = character.domains?.find(
         d => multiclassClassDomains.map(m => m.toLowerCase()).includes(d.toLowerCase())
       );

--- a/components/views/character/level-up/multiclass-selection.tsx
+++ b/components/views/character/level-up/multiclass-selection.tsx
@@ -17,7 +17,7 @@
 
 import React from 'react';
 import { Check } from 'lucide-react';
-import { getAllClassNames, getClassDomains } from '@/lib/level-up-helpers';
+import { getClassDomainsFromData, getClassNamesFromData, getSubclassesFromData } from '@/lib/level-up-helpers';
 
 interface MulticlassSelectionProps {
   primaryClassId?: string;
@@ -42,26 +42,16 @@ export default function MulticlassSelection({
   subclasses = [],
   classes = [],
 }: MulticlassSelectionProps) {
-  const allClasses = getAllClassNames();
-  const selectedClassDomains = selectedClass ? getClassDomains(selectedClass) : [];
+  // Use dynamic data from library instead of hard-coded SRD values
+  const allClassNames = getClassNamesFromData(classes);
 
-  // Filter subclasses for the selected class
-  // Use data from the classes table to find valid subclass names
-  // avoiding hardcoded maps.
-  let validSubclassNames: string[] = [];
-  if (selectedClass && classes.length > 0) {
-    const classData = classes.find(c => c.name === selectedClass);
-    if (classData?.data?.subclass_names) {
-      validSubclassNames = classData.data.subclass_names;
-    }
-  }
-  
-  const filteredSubclasses = selectedClass 
-    ? subclasses.filter(sc => 
-        // Match by explicit DB link (parent_class_id) OR by name found in class definition
-        sc.data?.parent_class_id === `class-${selectedClass.toLowerCase()}` ||
-        validSubclassNames.includes(sc.name)
-      )
+  // Find the selected class data for domain lookup
+  const selectedClassData = selectedClass ? classes.find((c: any) => c.name === selectedClass) : null;
+  const selectedClassDomains = getClassDomainsFromData(selectedClassData);
+
+  // Use dynamic subclass filtering with library data
+  const filteredSubclasses = selectedClassData
+    ? getSubclassesFromData(selectedClassData, subclasses)
     : [];
 
   return (
@@ -73,29 +63,30 @@ export default function MulticlassSelection({
           Select a second class to gain access to one of its domains
         </p>
         <div className="grid grid-cols-2 gap-2">
-          {allClasses.map((className) => {
+          {allClassNames.map((className: string) => {
+            const classData = classes.find((c: any) => c.name === className);
             const isSelected = selectedClass === className;
             const isPrimary = primaryClassId === className;
             const canSelect = !isPrimary;
-            const domains = getClassDomains(className);
+            const domains = getClassDomainsFromData(classData);
 
             return (
               <button
                 key={className}
                 onClick={() => {
-                    if (canSelect) {
-                        onSelectClass(className);
-                        // Reset subclass and domain when class changes
-                        onSelectSubclass('');
-                        onSelectDomain('');
-                    }
+                  if (canSelect) {
+                    onSelectClass(className);
+                    // Reset subclass and domain when class changes
+                    onSelectSubclass('');
+                    onSelectDomain('');
+                  }
                 }}
                 disabled={isPrimary}
                 className={`text-left p-3 rounded-lg border transition-all ${isSelected
-                    ? 'border-dagger-gold bg-dagger-gold/10'
-                    : isPrimary
-                      ? 'border-gray-700 bg-black/20 opacity-50 cursor-not-allowed'
-                      : 'border-gray-600 bg-black/30 hover:border-dagger-gold/50'
+                  ? 'border-dagger-gold bg-dagger-gold/10'
+                  : isPrimary
+                    ? 'border-gray-700 bg-black/20 opacity-50 cursor-not-allowed'
+                    : 'border-gray-600 bg-black/30 hover:border-dagger-gold/50'
                   }`}
               >
                 <div className="flex items-start justify-between">
@@ -127,44 +118,44 @@ export default function MulticlassSelection({
           </p>
           {filteredSubclasses.length === 0 ? (
             <div className="p-3 bg-yellow-900/20 border border-yellow-700/50 rounded-lg text-yellow-200 text-sm">
-                No subclasses found for {selectedClass}. Check library data.
+              No subclasses found for {selectedClass}. Check library data.
             </div>
           ) : (
             <div className="grid grid-cols-1 gap-2">
-                {filteredSubclasses.map((sub) => {
-                    const isSelected = selectedSubclass === sub.id;
-                    const description = sub.data?.description || '';
-                    const foundationFeatures = sub.data?.foundation_features || [];
+              {filteredSubclasses.map((sub) => {
+                const isSelected = selectedSubclass === sub.id;
+                const description = sub.data?.description || '';
+                const foundationFeatures = sub.data?.foundation_features || [];
 
-                    return (
-                        <button
-                            key={sub.id}
-                            onClick={() => onSelectSubclass(sub.id)}
-                            className={`text-left p-3 rounded-lg border transition-all ${isSelected
-                                ? 'border-dagger-gold bg-dagger-gold/10'
-                                : 'border-gray-600 bg-black/30 hover:border-dagger-gold/50'
-                            }`}
-                        >
-                            <div className="flex items-start justify-between gap-3">
-                                <div className="flex-1">
-                                    <p className="font-bold text-white">{sub.name}</p>
-                                    <p className="text-sm text-gray-300 line-clamp-2 mb-2">{description}</p>
-                                    
-                                    {/* Preview Foundation Feature(s) */}
-                                    {foundationFeatures.length > 0 && (
-                                        <div className="mt-2 p-2 bg-black/40 rounded border border-white/10">
-                                            <p className="text-xs font-bold text-dagger-gold uppercase mb-1">Foundation: {foundationFeatures[0].name}</p>
-                                            <p className="text-xs text-gray-400 line-clamp-3">{foundationFeatures[0].text}</p>
-                                        </div>
-                                    )}
-                                </div>
-                                {isSelected && (
-                                    <Check size={16} className="text-dagger-gold flex-shrink-0 mt-0.5" />
-                                )}
-                            </div>
-                        </button>
-                    );
-                })}
+                return (
+                  <button
+                    key={sub.id}
+                    onClick={() => onSelectSubclass(sub.id)}
+                    className={`text-left p-3 rounded-lg border transition-all ${isSelected
+                      ? 'border-dagger-gold bg-dagger-gold/10'
+                      : 'border-gray-600 bg-black/30 hover:border-dagger-gold/50'
+                      }`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex-1">
+                        <p className="font-bold text-white">{sub.name}</p>
+                        <p className="text-sm text-gray-300 line-clamp-2 mb-2">{description}</p>
+
+                        {/* Preview Foundation Feature(s) */}
+                        {foundationFeatures.length > 0 && (
+                          <div className="mt-2 p-2 bg-black/40 rounded border border-white/10">
+                            <p className="text-xs font-bold text-dagger-gold uppercase mb-1">Foundation: {foundationFeatures[0].name}</p>
+                            <p className="text-xs text-gray-400 line-clamp-3">{foundationFeatures[0].text}</p>
+                          </div>
+                        )}
+                      </div>
+                      {isSelected && (
+                        <Check size={16} className="text-dagger-gold flex-shrink-0 mt-0.5" />
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
             </div>
           )}
         </div>
@@ -178,7 +169,7 @@ export default function MulticlassSelection({
             Select one domain from {selectedClass} to add to your character
           </p>
           <div className="grid grid-cols-2 gap-2">
-            {selectedClassDomains.map((domain) => {
+            {selectedClassDomains.map((domain: string) => {
               const isSelected = selectedDomain === domain;
 
               return (
@@ -186,8 +177,8 @@ export default function MulticlassSelection({
                   key={domain}
                   onClick={() => onSelectDomain(domain)}
                   className={`text-left p-3 rounded-lg border transition-all ${isSelected
-                      ? 'border-dagger-gold bg-dagger-gold/10'
-                      : 'border-gray-600 bg-black/30 hover:border-dagger-gold/50'
+                    ? 'border-dagger-gold bg-dagger-gold/10'
+                    : 'border-gray-600 bg-black/30 hover:border-dagger-gold/50'
                     }`}
                 >
                   <div className="flex items-start justify-between">
@@ -211,7 +202,7 @@ export default function MulticlassSelection({
             <span className="font-bold text-white">{selectedDomain}</span> domain from{' '}
             <span className="font-bold text-white">{selectedClass}</span>, plus the{' '}
             <span className="font-bold text-white">
-                {subclasses.find(s => s.id === selectedSubclass)?.name || 'Unknown'}
+              {subclasses.find(s => s.id === selectedSubclass)?.name || 'Unknown'}
             </span> subclass Foundation Feature.
           </p>
         </div>

--- a/lib/character-templates.ts
+++ b/lib/character-templates.ts
@@ -1,3 +1,17 @@
+/**
+ * CHARACTER TEMPLATES (SRD-ONLY)
+ * ----------------------------------------------------------------------------
+ * Quick-fill templates for character creation. These templates provide
+ * pre-configured builds for each SRD class/subclass combination.
+ * 
+ * LIMITATION: These templates only support SRD classes.
+ * Playtest classes are not included and will return null from getTemplateForClass().
+ * 
+ * To add support for playtest classes, templates would need to be stored in the
+ * database alongside the class definitions, or a dynamic template generator
+ * would need to be created.
+ */
+
 import { CharacterFormData, LibraryData, LibraryLookupItem } from '@/components/character-creation/types';
 import { RangerCompanion } from '@/types/character';
 import classesData from '@/content/public/srd/json/classes.json';

--- a/lib/level-up-helpers.ts
+++ b/lib/level-up-helpers.ts
@@ -321,8 +321,23 @@ export function getLevelUpConfig(newLevel: number): {
 }
 
 /**
- * Gets the two domains for a given class.
+ * Gets the two domains for a given class from its library data.
  *
+ * This is the preferred dynamic version that works with any class (SRD or playtest).
+ *
+ * @param classData - The class LibraryItem with data.domains array
+ * @returns Array of domain names, or empty array if not found
+ */
+export function getClassDomainsFromData(classData: { data?: { domains?: string[] } } | null | undefined): string[] {
+  return classData?.data?.domains || [];
+}
+
+/**
+ * Gets the two domains for a given class by name.
+ *
+ * @deprecated Use getClassDomainsFromData() with library data instead.
+ * This function only works for SRD classes and will not support playtest content.
+ * 
  * Reference: srd/markdown/contents/Classes.md
  */
 export function getClassDomains(className: string): string[] {
@@ -342,25 +357,62 @@ export function getClassDomains(className: string): string[] {
 }
 
 /**
- * Gets all available class names.
+ * Gets all class names from library data.
+ *
+ * This is the preferred dynamic version that includes playtest classes.
+ *
+ * @param classes - Array of class LibraryItems
+ * @returns Array of class names
+ */
+export function getClassNamesFromData(classes: Array<{ name: string }>): string[] {
+  return classes.map(c => c.name);
+}
+
+/**
+ * Gets all available SRD class names.
+ *
+ * @deprecated Use getClassNamesFromData() with library data instead.
+ * This function only returns SRD classes and will not include playtest content.
  */
 export function getAllClassNames(): string[] {
   return ['Bard', 'Druid', 'Guardian', 'Ranger', 'Rogue', 'Seraph', 'Sorcerer', 'Warrior', 'Wizard'];
 }
 
 /**
- * Gets valid subclasses for a given class.
+ * Gets valid subclasses for a given class from library data.
+ *
+ * This is the preferred dynamic version that works with any class.
+ *
+ * @param classData - The parent class LibraryItem
+ * @param allSubclasses - Array of all subclass LibraryItems
+ * @returns Array of subclass LibraryItems that belong to this class
+ */
+export function getSubclassesFromData<T extends { id: string; name: string; data?: { parent_class_id?: string } }>(
+  classData: { id: string; name: string; data?: { subclass_names?: string[] } } | null | undefined,
+  allSubclasses: T[]
+): T[] {
+  if (!classData) return [];
+
+  const validSubclassNames = classData.data?.subclass_names || [];
+  const classIdSlug = `class-${classData.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+
+  return allSubclasses.filter(sc =>
+    sc.data?.parent_class_id === classIdSlug ||
+    validSubclassNames.includes(sc.name)
+  );
+}
+
+/**
+ * Gets valid subclasses for a given class by name.
+ *
+ * @deprecated Use getSubclassesFromData() with library data instead.
+ * This function is a placeholder that returns an empty array.
  *
  * @param className - The class name (e.g., "Warrior", "Bard")
- * @returns Array of subclass IDs for the class
- *
- * TODO: This should query the library table for subclasses:
- *   WHERE type='subclass' AND class_id=className
- * For now, returns empty array as placeholder.
+ * @returns Empty array (placeholder)
  */
 export function getSubclassesForClass(className: string): string[] {
-  // Placeholder implementation
-  // In production, this should query the library table
+  // Deprecated placeholder - use getSubclassesFromData instead
   return [];
 }
 


### PR DESCRIPTION
## Summary

Refactors hard-coded class/domain data to use database-driven functions, enabling multiclassing with playtest classes.

## Changes

### New Dynamic Functions (`lib/level-up-helpers.ts`)
- **`getClassDomainsFromData(classData)`** - Gets domains from LibraryItem, works with any class
- **`getClassNamesFromData(classes)`** - Gets class names from library array  
- **`getSubclassesFromData(classData, allSubclasses)`** - Filters subclasses dynamically with generic type preservation

### Updated Components
- **`multiclass-selection.tsx`** - Now uses `classes` prop with dynamic functions
- **`level-up-modal.tsx`** - Uses `getClassDomainsFromData` for domain lookups

### Deprecated (kept for backward compatibility)
- `getClassDomains(className)` - SRD-only, marked `@deprecated`
- `getAllClassNames()` - SRD-only, marked `@deprecated`
- `getSubclassesForClass(className)` - Placeholder, marked `@deprecated`

### Documentation
- `character-templates.ts` documented as SRD-only with limitation header

## Testing
- 30 tests passing including new dynamic function tests
- Build successful

## Audit Results
Other hard-coded data (domain colors, tier limits, trait names) was audited and determined to be acceptable as core game rules.

Closes #71